### PR TITLE
CFLAGS improvements (mostly compiler optimizations)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,8 @@ SRC = $(wildcard *.c)
 OBJ = $(SRC:.c=.o)
 EXEC ?= pk
 
-CFLAGS ?= -Wall -DDEBUG=1 -g
-CFLAGS_RELEASE ?= -Wall -DDEBUG=0
+CFLAGS ?= -Wall -DDEBUG=1 -g -pipe
+CFLAGS_RELEASE ?= -Wall -DDEBUG=0 -g0 -O2 -flto -march=native -fpie -Wl,-pie -pipe
 
 $(EXEC): $(OBJ)
 	$(CC) $(CFLAGS) -o $@ $^


### PR DESCRIPTION
- `-g0`: Disable debug symbols
- `-O2`: Recommended optimization level (use `O3` for clang but for gcc this can actually make the code slower)
- `-flto`: Link-time optimizations (might not be useful at this point)
- `-march=native`: Enable optimizations for your specific processor's architecture (SSE, AVX, etc.)
- `-fpie -Wl,-pie`: Full ASLR
- `-pipe`: Compiles faster by not creating temporary intermediate files